### PR TITLE
add the ocr recognize capatible for different resolution

### DIFF
--- a/scripts/calculate_qoe_metrics.sh
+++ b/scripts/calculate_qoe_metrics.sh
@@ -357,10 +357,9 @@ align_ocr() {
       f=${files[$i]}
       filename=$(basename $f)
 
-      crop_value=100x45+270+430
-      if [ $WIDTH -eq 1280 ] && [ $HEIGHT -eq 720 ]; then
-         crop_value=100x45+590+670
-      fi
+      left=`expr $WIDTH / 2 - 50`
+      top=`expr $HEIGHT - 50`
+      crop_value=100x45+$left+$top
       convert $f -crop $crop_value $cut_folder/_$filename
 
       #frame=$(tesseract $cut_folder/_$filename stdout --psm 7 digits 2>/dev/null | sed -r '/^\s*$/d')


### PR DESCRIPTION
For different resolution, the order of convert should crop different position to get label.
The position of label rectangle should be (left, top) = (Width/2-50, Height-50).
The size of label rectangle is 100x45.
The explanation of convert is [here](https://askubuntu.com/questions/631689/cropping-images-using-command-line-tools-only)